### PR TITLE
timeshift target name was missing ", added them.

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -2489,7 +2489,7 @@ def timeShift(requestContext, seriesList, timeShift, resetEnd=True):
     series = seriesList[0]
 
     for shiftedSeries in evaluateTarget(myContext, series.pathExpression):
-      shiftedSeries.name = 'timeShift(%s, %s)' % (shiftedSeries.name, timeShift)
+      shiftedSeries.name = 'timeShift(%s, "%s")' % (shiftedSeries.name, timeShift)
       if resetEnd:
         shiftedSeries.end = series.end
       else:


### PR DESCRIPTION
timeShift was supposed to return a target name like: 
timeShift(Sales.widgets.largeBlue,"-7d")
However, due to missing Quotation marks the actual result was:
timeShift(Sales.widgets.largeBlue,-7d)
